### PR TITLE
Add CI for running tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    strategy:
+      matrix:
+        pg: [15, 14, 13, 12, 11, 10]
+    name: 🐘 PostgreSQL ${{ matrix.pg }}
+    runs-on: ubuntu-latest
+    container: pgxn/pgxn-tools
+    steps:
+      - run: pg-start ${{ matrix.pg }}
+      - uses: actions/checkout@v3
+      - run: pg-build-test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 EXTENSION = pg_statviz
-MODULES = pg_statviz
 DATA = pg_statviz--0.1.sql
 DOCS = README.md
 REGRESS = pg_statviz_test


### PR DESCRIPTION
Changes:
- Add a Github action that runs tests on different Postgres versions(15,14,13,12,11,10).
- Remove `MODULES` from Makefile.

Observation:
Currently tests for pg_version<15 fail since the function `pgstatviz.snapshot_wal` is present only in Postgres versions >= 15 thereby making the tests fail for versions lower than 15, since `pgstatviz.snapshot` calls `pgstatviz.snapshot_wal` which is not present. This would be fixed in another PR.