### PR TITLE
Fix: unmarshalling extra values

### DIFF
--- a/src/pg_statviz/libs/info.py
+++ b/src/pg_statviz/libs/info.py
@@ -31,17 +31,15 @@ def getinfo(conn):
                        SELECT hostname,
                               inet_server_addr()
                        FROM _info""")
-        info['hostname'], info['inet_server_addr'], info['block_size'] \
-            = cur.fetchone()
+        info['hostname'], info['inet_server_addr'] = cur.fetchone()
         cur.close()
     except (ExternalRoutineException, InsufficientPrivilege) as e:
         conn.rollback()
         cur = conn.cursor()
         _logger.warning("Context: getting hostname")
         _logger.warning(e)
-        cur.execute("""SELECT inet_server_addr(),
-                              current_setting('block_size')""")
-        info['inet_server_addr'], info['block_size'] = cur.fetchone()
+        cur.execute("""SELECT inet_server_addr()""")
+        info['inet_server_addr'] = cur.fetchone()
         info['hostname'] = conn.get_dsn_parameters()['host']
         _logger.info(f"""Setting hostname to "{info['hostname']}" """)
         cur.close()


### PR DESCRIPTION
Unmarshalling extra values which haven't been fetched in the query.
`blocksz` has been shifted to `pgstatviz.db` table earlier 