### PR TITLE
fix: Warn with error if PG version<16 when running io analysis

### DIFF
--- a/src/pg_statviz/modules/io.py
+++ b/src/pg_statviz/modules/io.py
@@ -70,7 +70,15 @@ def io(dbname=getpass.getuser(), host="/var/run/postgresql", port="5432",
 
     data = cur.fetchmany(MAX_RESULTS)
     if not data:
-        raise SystemExit("No pg_statviz snapshots found in this database")
+        cur.execute("""SELECT
+                    (current_setting('server_version_num')::int >= 160000)""")
+        versioncheck = cur.fetchone()[0]
+        if not versioncheck:
+            _logger.error("Buffer IO analysis is only available from "
+                          + "PostgreSQL release 16 onwards")
+            return
+        else:
+            raise SystemExit("No pg_statviz snapshots found in this database")
 
     tstamps = [ts['snapshot_tstamp'] for ts in data]
     blcksz = int(data[0]['block_size'])


### PR DESCRIPTION
- Buffer IO analysis requires PostgreSQL version 16.