### PR TITLE
PR for release 1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         needs: lint-and-build
         strategy:
             matrix:
-                pg_version: [13, 14, 15, 16, 17, 18]
+                pg_version: [13, 14, 15, 16, 17, 18, 19]
         steps:
             - name: Check out code
               uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
             - name: Install PostgreSQL ${{ matrix.pg_version }}
               run: |
                   wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
-                  echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+                  echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main 19" | sudo tee /etc/apt/sources.list.d/pgdg.list
                   sudo apt-get update
                   sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
 
@@ -101,7 +101,7 @@ jobs:
         needs: lint-and-build
         strategy:
             matrix:
-                pg_version: [13, 14, 15, 16, 17, 18]
+                pg_version: [13, 14, 15, 16, 17, 18, 19]
         steps:
             - name: Check out code
               uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
             - name: Install PostgreSQL ${{ matrix.pg_version }}
               run: |
                   wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
-                  echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+                  echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main 19" | sudo tee /etc/apt/sources.list.d/pgdg.list
                   sudo apt-get update
                   sudo apt-get install -y postgresql-${{ matrix.pg_version }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ Temporary Items
 /regression.diffs
 /regression.out
 /results/
+
+# Local CI logs
+/ci-*.log

--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
    "name": "pg_statviz",
    "abstract": "PostgreSQL stats visualization over time",
    "description": "pg_statviz is a minimalist extension and utility pair for time series analysis and visualization of PostgreSQL internal statistics.",
-   "version": "1.1.0",
+   "version": "1.2.0",
    "release_status": "stable",
    "maintainer": "Jimmy Angelakos <vyruss@hellug.gr>",
    "license": {
@@ -21,9 +21,9 @@
    },
    "provides": {
      "pg_statviz": {
-       "file": "pg_statviz--1.1.sql",
+       "file": "pg_statviz--1.2.sql",
        "docfile": "README.md",
-       "version": "1.1.0",
+       "version": "1.2.0",
        "abstract": "PostgreSQL stats visualization over time"
      }
    },

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ visualizations for selected time ranges from the stored statistic snapshots, hel
 PostgreSQL performance over time and potentially aiding in performance tuning and troubleshooting.
 
 Optionally, an [AI analysis](#ai-analysis-optional) mode can produce per-module HTML reports
-with chart commentary from a cloud LLM (Claude or Gemini) or a local model via Ollama.
+with chart commentary from a cloud LLM (Claude, Gemini, or OpenAI), any OpenAI-compatible
+endpoint, or a local model via Ollama.
 
 [![Wait events](src/pg_statviz/libs/pg_statviz_srv.example.com_5432_wait.png)](src/pg_statviz/libs/pg_statviz_srv.example.com_5432_wait.png)
 
@@ -98,7 +99,7 @@ using `dnf` or `yum`:
 ### Requirements
 
 Python 3.11+ is required for the visualization utility.
-Any recent PostgreSQL version up to and including 18 is supported.
+Any recent PostgreSQL version up to and including 19 is supported.
 
 ## Usage
 
@@ -168,9 +169,9 @@ The visualization utility can be called like a PostgreSQL command line tool:
 
 [comment]::
 
-    usage: pg_statviz [--help] [--version] [-d DBNAME] [-h HOSTNAME] [-p PORT]
-                      [-U USERNAME] [-W] [-D FROM TO] [-O OUTPUTDIR]
-                      {analyze,buf,cache,checkp,checksum,conn,io,lock,repl,slru,tuple,wait,wal,xact} ...
+    usage: pg_statviz [-?] [--version] [-d DBNAME] [-h HOSTNAME] [-p PORT] [-U USERNAME] [-W]
+                      [-D FROM TO] [-O OUTPUTDIR] [--ai [PROVIDER]]
+                      {analyze,buf,cache,checkp,checksum,conf,conn,io,lock,repl,slru,tuple,wait,wal,xact} ...
 
     run all analysis modules
 
@@ -193,21 +194,22 @@ The visualization utility can be called like a PostgreSQL command line tool:
         xact                run transaction count analysis module
 
     options:
-      --help
+      -?, --help            show this help, then exit
       --version             show program's version number and exit
-      -d DBNAME, --dbname DBNAME
-                            database name to analyze (default: 'myuser')
-      -h HOSTNAME, --host HOSTNAME
-                            database server host or socket directory (default: '/var/run/postgresql')
-      -p PORT, --port PORT  database server port (default: '5432')
-      -U USERNAME, --username USERNAME
+      -d, --dbname DBNAME   database name to analyze (default: 'myuser')
+      -h, --host HOSTNAME   database server host or socket directory (default: '/var/run/postgresql')
+      -p, --port PORT       database server port (default: '5432')
+      -U, --username USERNAME
                             database user name (default: 'myuser')
-      -W, --password        force password prompt (should happen automatically) (default: False)
-      -D FROM TO, --daterange FROM TO
+      -W, --password        force password prompt (should happen automatically) (default: -)
+      -D, --daterange FROM TO
                             date range to be analyzed in ISO 8601 format e.g. 2026-01-01T00:00
                             2026-01-01T23:59 (default: [])
-      -O OUTPUTDIR, --outputdir OUTPUTDIR
+      -O, --outputdir OUTPUTDIR
                             output directory (default: -)
+      --ai [PROVIDER]       enable AI analysis (default provider: claude). Choices: claude
+                            (Anthropic), gemini (Google), openai (OpenAI/compatible), local (Ollama).
+                            (default: -)
 
 ### Specific module usage
 
@@ -215,27 +217,29 @@ The visualization utility can be called like a PostgreSQL command line tool:
 
 [comment]::
 
-    usage: pg_statviz conn [-h] [-d DBNAME] [--host HOSTNAME] [-p PORT] [-U USERNAME] [-W]
-                           [-D FROM TO] [-O OUTPUTDIR] [-u [USERS ...]]
+    usage: pg_statviz conn [-d DBNAME] [-h HOSTNAME] [-p PORT] [-U USERNAME] [-W] [-D FROM TO]
+                           [-O OUTPUTDIR] [--ai [PROVIDER]] [-u [USERS ...]] [-?]
 
     run connection count analysis module
 
     options:
-      -h, --help            show this help message and exit
-      -d DBNAME, --dbname DBNAME
-                            database name to analyze (default: 'myuser')
-      --host HOSTNAME       database server host or socket directory (default: '/var/run/postgresql')
-      -p PORT, --port PORT  database server port (default: '5432')
-      -U USERNAME, --username USERNAME
+      -d, --dbname DBNAME   database name to analyze (default: 'myuser')
+      -h, --host HOSTNAME   database server host or socket directory (default: '/var/run/postgresql')
+      -p, --port PORT       database server port (default: '5432')
+      -U, --username USERNAME
                             database user name (default: 'myuser')
-      -W, --password        force password prompt (should happen automatically) (default: False)
-      -D FROM TO, --daterange FROM TO
+      -W, --password        force password prompt (should happen automatically) (default: -)
+      -D, --daterange FROM TO
                             date range to be analyzed in ISO 8601 format e.g. 2026-01-01T00:00
                             2026-01-01T23:59 (default: [])
-      -O OUTPUTDIR, --outputdir OUTPUTDIR
+      -O, --outputdir OUTPUTDIR
                             output directory (default: -)
-      -u [USERS ...], --users [USERS ...]
+      --ai [PROVIDER]       enable AI analysis (default provider: claude). Choices: claude
+                            (Anthropic), gemini (Google), openai (OpenAI/compatible), local (Ollama).
+                            (default: -)
+      -u, --users [USERS ...]
                             user name(s) to plot in analysis (default: [])
+      -?, --help            show this help, then exit
 
 ### Example:
 
@@ -261,17 +265,29 @@ concrete remediation step for any [WARNING] or [CRITICAL] finding.
 
 ### Enabling AI analysis
 
-Add `--ai` (or `-A`) to any command:
+Add `--ai` to any command:
 
     pg_statviz analyze -d mydb --ai
 
-This uses Claude by default. Three providers are available:
+This uses Claude by default. Four providers are available:
 
 Provider | Flag | Requires
 --- | --- | ---
 [Claude](https://www.anthropic.com/) (Anthropic) | `--ai claude` or `--ai` | `ANTHROPIC_API_KEY`
 [Gemini](https://aistudio.google.com/) (Google AI Studio) | `--ai gemini` | `GOOGLE_API_KEY`
+[OpenAI](https://platform.openai.com/) or compatible | `--ai openai` | `OPENAI_API_KEY`
 Local ([Ollama](https://ollama.com/)) | `--ai local` | Ollama running with `gemma4:e4b`
+
+Whichever provider you pick, the model has to be vision-capable: the charts are
+sent as PNGs alongside the numbers.
+
+For a compatible endpoint (vLLM, LM Studio, llama.cpp, OpenRouter, Groq), set
+`OPENAI_BASE_URL` and `OPENAI_MODEL`:
+
+    export OPENAI_BASE_URL=http://localhost:8000/v1
+    export OPENAI_API_KEY=unused
+    export OPENAI_MODEL=Qwen/Qwen3-VL-8B-Instruct
+    pg_statviz analyze -d mydb --ai openai
 
 ### Installing AI dependencies
 
@@ -293,7 +309,7 @@ images and renders the AI analysis as styled HTML.
 When the `analyze` subcommand is invoked with `--ai`, an additional top-level
 `pg_statviz_<host>_<port>_index.html` report is generated. It synthesises the
 per-module verdicts into a single cross-cutting summary, correlating patterns
-across charts and surfacing the single most important next action.
+across charts and suggesting the single most important next action.
 
 [![AI report sample](src/pg_statviz/libs/pg_statviz_ai_report_sample.png)](src/pg_statviz/libs/pg_statviz_ai_report_sample.png)
 

--- a/pg_statviz--1.1--1.2.sql
+++ b/pg_statviz--1.1--1.2.sql
@@ -1,0 +1,106 @@
+/*
+// pg_statviz--1.1--1.2.sql - Upgrade extension to 1.2
+*/
+
+-- Add WAL full page image bytes tracking to wal table (PG19+)
+ALTER TABLE @extschema@.wal ADD COLUMN wal_fpi_bytes bigint;
+
+-- Update snapshot_conf to capture PG18/PG19 IO worker, WAL level and
+-- autovacuum scoring settings (absent settings are simply skipped)
+CREATE OR REPLACE FUNCTION @extschema@.snapshot_conf(snapshot_tstamp timestamptz)
+RETURNS void
+AS $$
+DECLARE
+    current_conf jsonb;
+    previous_conf jsonb;
+BEGIN
+    SELECT jsonb_object_agg("variable", "value")
+    INTO current_conf
+    FROM (
+        SELECT "name" AS "variable",
+               "setting" AS "value"
+        FROM pg_settings
+        WHERE "name" IN (
+            'autovacuum',
+            'autovacuum_max_workers',
+            'autovacuum_naptime',
+            'autovacuum_work_mem',
+            'bgwriter_delay',
+            'bgwriter_lru_maxpages',
+            'bgwriter_lru_multiplier',
+            'checkpoint_completion_target',
+            'checkpoint_timeout',
+            'max_connections',
+            'max_wal_size',
+            'max_wal_senders',
+            'work_mem',
+            'maintenance_work_mem',
+            'max_replication_slots',
+            'max_parallel_workers',
+            'max_parallel_maintenance_workers',
+            'server_version_num',
+            'shared_buffers',
+            'vacuum_cost_delay',
+            'vacuum_cost_limit',
+            'effective_wal_level',
+            'io_min_workers',
+            'io_max_workers',
+            'io_worker_idle_timeout',
+            'io_worker_launch_interval',
+            'autovacuum_max_parallel_workers',
+            'autovacuum_vacuum_score_weight',
+            'autovacuum_vacuum_insert_score_weight',
+            'autovacuum_analyze_score_weight',
+            'autovacuum_freeze_score_weight',
+            'autovacuum_multixact_freeze_score_weight')) s;
+
+    SELECT c1.conf INTO previous_conf
+    FROM @extschema@.conf c1
+    WHERE c1.snapshot_tstamp = (SELECT MAX(c2.snapshot_tstamp) FROM @extschema@.conf c2);
+
+    IF previous_conf IS NULL OR current_conf IS DISTINCT FROM previous_conf THEN
+        INSERT INTO @extschema@.conf (snapshot_tstamp, conf)
+        VALUES (snapshot_conf.snapshot_tstamp, current_conf);
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Update snapshot_wal to capture wal_fpi_bytes on PG19+
+DO $block$
+BEGIN
+    IF (SELECT current_setting('server_version_num')::int >= 190000) THEN
+        -- PG19 adds wal_fpi_bytes to pg_stat_wal
+        CREATE OR REPLACE FUNCTION @extschema@.snapshot_wal(snapshot_tstamp timestamptz)
+        RETURNS void
+        AS $$
+            INSERT INTO @extschema@.wal (
+                    snapshot_tstamp,
+                    wal_records,
+                    wal_fpi,
+                    wal_fpi_bytes,
+                    wal_bytes,
+                    wal_buffers_full,
+                    wal_write,
+                    wal_sync,
+                    wal_write_time,
+                    wal_sync_time,
+                    stats_reset)
+                SELECT
+                    snapshot_tstamp,
+                    w.wal_records,
+                    w.wal_fpi,
+                    w.wal_fpi_bytes,
+                    w.wal_bytes,
+                    w.wal_buffers_full,
+                    SUM(io.writes),
+                    SUM(io.fsyncs),
+                    SUM(io.write_time),
+                    SUM(io.fsync_time),
+                    w.stats_reset
+                FROM pg_stat_wal w, pg_stat_io io
+                WHERE io.object = 'wal'
+                GROUP BY w.wal_records, w.wal_fpi, w.wal_fpi_bytes, w.wal_bytes, w.wal_buffers_full, w.stats_reset;
+        $$ LANGUAGE SQL;
+    END IF;
+END
+$block$ LANGUAGE PLPGSQL;

--- a/pg_statviz--1.2.sql
+++ b/pg_statviz--1.2.sql
@@ -1,0 +1,711 @@
+/*
+// pg_statviz - stats visualization and time series analysis
+//
+// Copyright (c) 2026 Jimmy Angelakos
+// This software is released under the PostgreSQL Licence
+//
+// pg_statviz 1.2
+*/
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION pg_statviz" to load this file. \quit
+
+
+CREATE TABLE IF NOT EXISTS @extschema@.snapshots(
+    snapshot_tstamp timestamptz PRIMARY KEY
+);
+
+
+-- Buffers and checkpoints
+CREATE TABLE IF NOT EXISTS @extschema@.buf(
+    snapshot_tstamp timestamptz REFERENCES @extschema@.snapshots(snapshot_tstamp) ON DELETE CASCADE PRIMARY KEY,
+    checkpoints_timed bigint,
+    checkpoints_req bigint,
+    checkpoint_write_time double precision,
+    checkpoint_sync_time double precision,
+    buffers_checkpoint bigint,
+    buffers_clean bigint,
+    maxwritten_clean bigint,
+    buffers_backend bigint,
+    buffers_backend_fsync bigint,
+    buffers_alloc bigint,
+    stats_reset timestamptz);
+
+-- PG17+ moved things out of pg_stat_bgwriter
+DO $block$
+BEGIN
+    IF (SELECT current_setting('server_version_num')::int >= 170000) THEN
+        CREATE OR REPLACE FUNCTION @extschema@.snapshot_buf(snapshot_tstamp timestamptz)
+        RETURNS void
+        AS $$
+            INSERT INTO @extschema@.buf (
+                snapshot_tstamp,
+                checkpoints_timed,
+                checkpoints_req,
+                checkpoint_write_time,
+                checkpoint_sync_time,
+                buffers_checkpoint,
+                buffers_clean,
+                maxwritten_clean,
+                buffers_backend,
+                buffers_backend_fsync,
+                buffers_alloc,
+                stats_reset)
+            SELECT
+                snapshot_tstamp,
+                c.num_timed,
+                c.num_requested,
+                c.write_time,
+                c.sync_time,
+                c.buffers_written,
+                b.buffers_clean,
+                b.maxwritten_clean,
+                i.writes,
+                i.fsyncs,
+                b.buffers_alloc,
+                b.stats_reset
+            FROM pg_stat_bgwriter b, pg_stat_checkpointer c, pg_stat_io i
+            WHERE i.backend_type = 'client backend'
+            AND i.context = 'normal'
+            AND i.object = 'relation';
+        $$ LANGUAGE SQL;
+    ELSE
+        CREATE OR REPLACE FUNCTION @extschema@.snapshot_buf(snapshot_tstamp timestamptz)
+        RETURNS void
+        AS $$
+            INSERT INTO @extschema@.buf (
+                snapshot_tstamp,
+                checkpoints_timed,
+                checkpoints_req,
+                checkpoint_write_time,
+                checkpoint_sync_time,
+                buffers_checkpoint,
+                buffers_clean,
+                maxwritten_clean,
+                buffers_backend,
+                buffers_backend_fsync,
+                buffers_alloc,
+                stats_reset)
+            SELECT
+                snapshot_tstamp,
+                checkpoints_timed,
+                checkpoints_req,
+                checkpoint_write_time,
+                checkpoint_sync_time,
+                buffers_checkpoint,
+                buffers_clean,
+                maxwritten_clean,
+                buffers_backend,
+                buffers_backend_fsync,
+                buffers_alloc,
+                stats_reset
+            FROM pg_stat_bgwriter;
+        $$ LANGUAGE SQL;
+    END IF;
+END
+$block$ LANGUAGE PLPGSQL;
+
+
+-- Configuration
+CREATE TABLE IF NOT EXISTS @extschema@.conf(
+    snapshot_tstamp timestamptz REFERENCES @extschema@.snapshots(snapshot_tstamp) ON DELETE CASCADE PRIMARY KEY,
+    conf jsonb);
+
+CREATE OR REPLACE FUNCTION @extschema@.snapshot_conf(snapshot_tstamp timestamptz)
+RETURNS void
+AS $$
+DECLARE
+    current_conf jsonb;
+    previous_conf jsonb;
+BEGIN
+    SELECT jsonb_object_agg("variable", "value")
+    INTO current_conf
+    FROM (
+        SELECT "name" AS "variable",
+               "setting" AS "value"
+        FROM pg_settings
+        WHERE "name" IN (
+            'autovacuum',
+            'autovacuum_max_workers',
+            'autovacuum_naptime',
+            'autovacuum_work_mem',
+            'bgwriter_delay',
+            'bgwriter_lru_maxpages',
+            'bgwriter_lru_multiplier',
+            'checkpoint_completion_target',
+            'checkpoint_timeout',
+            'max_connections',
+            'max_wal_size',
+            'max_wal_senders',
+            'work_mem',
+            'maintenance_work_mem',
+            'max_replication_slots',
+            'max_parallel_workers',
+            'max_parallel_maintenance_workers',
+            'server_version_num',
+            'shared_buffers',
+            'vacuum_cost_delay',
+            'vacuum_cost_limit',
+            'effective_wal_level',
+            'io_min_workers',
+            'io_max_workers',
+            'io_worker_idle_timeout',
+            'io_worker_launch_interval',
+            'autovacuum_max_parallel_workers',
+            'autovacuum_vacuum_score_weight',
+            'autovacuum_vacuum_insert_score_weight',
+            'autovacuum_analyze_score_weight',
+            'autovacuum_freeze_score_weight',
+            'autovacuum_multixact_freeze_score_weight')) s;
+
+    SELECT c1.conf INTO previous_conf
+    FROM @extschema@.conf c1
+    WHERE c1.snapshot_tstamp = (SELECT MAX(c2.snapshot_tstamp) FROM @extschema@.conf c2);
+
+    IF previous_conf IS NULL OR current_conf IS DISTINCT FROM previous_conf THEN
+        INSERT INTO @extschema@.conf (snapshot_tstamp, conf)
+        VALUES (snapshot_conf.snapshot_tstamp, current_conf);
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- Connections
+CREATE TABLE IF NOT EXISTS @extschema@.conn(
+    snapshot_tstamp timestamptz REFERENCES @extschema@.snapshots(snapshot_tstamp) ON DELETE CASCADE PRIMARY KEY,
+    conn_total int,
+    conn_active int,
+    conn_idle int,
+    conn_idle_trans int,
+    conn_idle_trans_abort int,
+    conn_fastpath int,
+    conn_users jsonb,
+    max_query_age_seconds double precision,
+    max_xact_age_seconds double precision,
+    max_backend_age_seconds double precision);
+
+CREATE OR REPLACE FUNCTION @extschema@.snapshot_conn(snapshot_tstamp timestamptz)
+RETURNS void
+AS $$
+    WITH
+        pgsa AS (
+            SELECT *
+            FROM pg_stat_activity
+            WHERE datname = current_database()
+            AND state IS NOT NULL),
+        userconns AS (
+            SELECT jsonb_agg(uc)
+            FROM (
+                SELECT usename AS user, count(*) AS connections
+                FROM pgsa
+                WHERE usename IS NOT NULL
+                GROUP BY usename) uc),
+        maxages AS (
+            SELECT
+                date_part('epoch', max(clock_timestamp() - query_start)) AS max_query_age,
+                date_part('epoch', max(clock_timestamp() - xact_start)) AS max_xact_age,
+                date_part('epoch', max(clock_timestamp() - backend_start)) AS max_backend_age
+            FROM pgsa
+            WHERE state != 'idle')
+    INSERT INTO @extschema@.conn (
+        snapshot_tstamp,
+        conn_total,
+        conn_active,
+        conn_idle,
+        conn_idle_trans,
+        conn_idle_trans_abort,
+        conn_fastpath,
+        conn_users,
+        max_query_age_seconds,
+        max_xact_age_seconds,
+        max_backend_age_seconds)
+    SELECT
+        snapshot_tstamp,
+        count(*) AS conn_total,
+        count(*) FILTER (WHERE state = 'active') AS conn_active,
+        count(*) FILTER (WHERE state = 'idle') AS conn_idle,
+        count(*) FILTER (WHERE state = 'idle in transaction') AS conn_idle_trans,
+        count(*) FILTER (WHERE state = 'idle in transaction (aborted)') AS conn_idle_trans_abort,
+        count(*) FILTER (WHERE state = 'fastpath function call') AS conn_fastpath,
+        (SELECT * from userconns) AS conn_users,
+        (SELECT max_query_age FROM maxages),
+        (SELECT max_xact_age FROM maxages),
+        (SELECT max_backend_age FROM maxages)
+    FROM pgsa;
+$$ LANGUAGE SQL;
+
+
+-- Locks
+CREATE TABLE IF NOT EXISTS @extschema@.lock(
+    snapshot_tstamp timestamptz REFERENCES @extschema@.snapshots(snapshot_tstamp) ON DELETE CASCADE PRIMARY KEY,
+    locks_total int,
+    locks jsonb);
+
+CREATE OR REPLACE FUNCTION @extschema@.snapshot_lock(snapshot_tstamp timestamptz)
+RETURNS void
+AS $$
+    WITH
+        pgl AS (
+            SELECT *
+            FROM pg_locks l, pg_database d
+            WHERE d.datname = current_database()
+            AND l.database = oid
+            AND locktype = 'relation'
+            AND pid != pg_backend_pid()), -- ignore snapshot session
+        lcks AS (
+            SELECT coalesce(jsonb_agg(l), '[]'::jsonb)
+            FROM (
+                SELECT mode AS lock_mode, count(*) AS lock_count
+                FROM pgl
+                GROUP BY lock_mode) l)
+    INSERT INTO @extschema@.lock (
+        snapshot_tstamp,
+        locks_total,
+        locks)
+    SELECT
+        snapshot_tstamp,
+        count(*) AS locks_total,
+        (SELECT * from lcks) AS locks
+    FROM pgl;
+$$ LANGUAGE SQL;
+
+
+-- Replication
+CREATE TABLE IF NOT EXISTS @extschema@.repl(
+    snapshot_tstamp timestamptz REFERENCES @extschema@.snapshots(snapshot_tstamp) ON DELETE CASCADE PRIMARY KEY,
+    standby_lag jsonb,
+    slot_stats jsonb);
+
+CREATE OR REPLACE FUNCTION @extschema@.snapshot_repl(snapshot_tstamp timestamptz)
+RETURNS void
+AS $$
+    WITH
+        standbys AS (
+            SELECT jsonb_agg(jsonb_build_object(
+                'application_name', application_name,
+                'state', state,
+                'sync_state', sync_state,
+                'lag_bytes', pg_wal_lsn_diff(pg_current_wal_lsn(), sent_lsn),
+                'lag_seconds', date_part('epoch', clock_timestamp() - reply_time)
+            )) AS standby_lag
+            FROM pg_stat_replication),
+        slots AS (
+            SELECT jsonb_agg(jsonb_build_object(
+                'slot_name', slot_name,
+                'slot_type', slot_type,
+                'active', active,
+                'wal_bytes', CASE
+                    WHEN pg_is_in_recovery() THEN NULL
+                    ELSE pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)
+                END
+            )) AS slot_stats
+            FROM pg_replication_slots
+            WHERE slot_type = 'physical'
+               OR database = current_database())
+    INSERT INTO @extschema@.repl (
+        snapshot_tstamp,
+        standby_lag,
+        slot_stats)
+    SELECT
+        snapshot_tstamp,
+        (SELECT standby_lag FROM standbys),
+        (SELECT slot_stats FROM slots);
+$$ LANGUAGE SQL;
+
+
+-- SLRU
+CREATE TABLE IF NOT EXISTS @extschema@.slru(
+    snapshot_tstamp timestamptz REFERENCES @extschema@.snapshots(snapshot_tstamp) ON DELETE CASCADE PRIMARY KEY,
+    slru_stats jsonb);
+
+CREATE OR REPLACE FUNCTION @extschema@.snapshot_slru(snapshot_tstamp timestamptz)
+RETURNS void
+AS $$
+    INSERT INTO @extschema@.slru (
+        snapshot_tstamp,
+        slru_stats)
+    SELECT
+        snapshot_tstamp,
+        jsonb_agg(jsonb_build_object(
+            'name', name,
+            'blks_zeroed', blks_zeroed,
+            'blks_hit', blks_hit,
+            'blks_read', blks_read,
+            'blks_written', blks_written,
+            'blks_exists', blks_exists,
+            'flushes', flushes,
+            'truncates', truncates
+        ))
+    FROM pg_stat_slru;
+$$ LANGUAGE SQL;
+
+
+-- Wait events
+CREATE TABLE IF NOT EXISTS @extschema@.wait(
+    snapshot_tstamp timestamptz REFERENCES @extschema@.snapshots(snapshot_tstamp) ON DELETE CASCADE PRIMARY KEY,
+    wait_events_total int,
+    wait_events jsonb);
+
+CREATE OR REPLACE FUNCTION @extschema@.snapshot_wait(snapshot_tstamp timestamptz)
+RETURNS void
+AS $$
+    WITH
+        pgsa AS (
+            SELECT *
+            FROM pg_stat_activity
+            WHERE datname = current_database()
+            AND state = 'active'
+            AND wait_event IS NOT NULL),
+        waitevents AS (
+            SELECT coalesce(jsonb_agg(we), '[]'::jsonb)
+            FROM (
+                SELECT wait_event_type, wait_event, count(*) AS wait_event_count
+                FROM pgsa
+                GROUP BY wait_event_type, wait_event) we)
+    INSERT INTO @extschema@.wait (
+        snapshot_tstamp,
+        wait_events_total,
+        wait_events)
+    SELECT
+        snapshot_tstamp,
+        count(*) AS wait_events_total,
+        (SELECT * from waitevents) AS wait_events
+    FROM pgsa;
+$$ LANGUAGE SQL;
+
+
+-- WAL
+CREATE TABLE IF NOT EXISTS @extschema@.wal(
+    snapshot_tstamp timestamptz REFERENCES @extschema@.snapshots(snapshot_tstamp) ON DELETE CASCADE PRIMARY KEY,
+    wal_records bigint,
+    wal_fpi bigint,
+    wal_fpi_bytes bigint,
+    wal_bytes numeric,
+    wal_buffers_full bigint,
+    wal_write bigint,
+    wal_sync bigint,
+    wal_write_time double precision,
+    wal_sync_time double precision,
+    stats_reset timestamptz);
+
+-- pg_stat_wal only exists in PG14+
+DO $block$
+BEGIN
+    IF (SELECT current_setting('server_version_num')::int >= 190000) THEN
+        -- PG19 adds wal_fpi_bytes to pg_stat_wal
+        CREATE OR REPLACE FUNCTION @extschema@.snapshot_wal(snapshot_tstamp timestamptz)
+        RETURNS void
+        AS $$
+            INSERT INTO @extschema@.wal (
+                    snapshot_tstamp,
+                    wal_records,
+                    wal_fpi,
+                    wal_fpi_bytes,
+                    wal_bytes,
+                    wal_buffers_full,
+                    wal_write,
+                    wal_sync,
+                    wal_write_time,
+                    wal_sync_time,
+                    stats_reset)
+                SELECT
+                    snapshot_tstamp,
+                    w.wal_records,
+                    w.wal_fpi,
+                    w.wal_fpi_bytes,
+                    w.wal_bytes,
+                    w.wal_buffers_full,
+                    SUM(io.writes),
+                    SUM(io.fsyncs),
+                    SUM(io.write_time),
+                    SUM(io.fsync_time),
+                    w.stats_reset
+                FROM pg_stat_wal w, pg_stat_io io
+                WHERE io.object = 'wal'
+                GROUP BY w.wal_records, w.wal_fpi, w.wal_fpi_bytes, w.wal_bytes, w.wal_buffers_full, w.stats_reset;
+        $$ LANGUAGE SQL;
+    ELSIF (SELECT current_setting('server_version_num')::int >= 180000) THEN
+        -- PG18 moved wal_write/wal_sync statistics to pg_stat_io (object = 'wal')
+        CREATE OR REPLACE FUNCTION @extschema@.snapshot_wal(snapshot_tstamp timestamptz)
+        RETURNS void
+        AS $$
+            INSERT INTO @extschema@.wal (
+                    snapshot_tstamp,
+                    wal_records,
+                    wal_fpi,
+                    wal_bytes,
+                    wal_buffers_full,
+                    wal_write,
+                    wal_sync,
+                    wal_write_time,
+                    wal_sync_time,
+                    stats_reset)
+                SELECT
+                    snapshot_tstamp,
+                    w.wal_records,
+                    w.wal_fpi,
+                    w.wal_bytes,
+                    w.wal_buffers_full,
+                    SUM(io.writes),
+                    SUM(io.fsyncs),
+                    SUM(io.write_time),
+                    SUM(io.fsync_time),
+                    w.stats_reset
+                FROM pg_stat_wal w, pg_stat_io io
+                WHERE io.object = 'wal'
+                GROUP BY w.wal_records, w.wal_fpi, w.wal_bytes, w.wal_buffers_full, w.stats_reset;
+        $$ LANGUAGE SQL;
+    ELSIF (SELECT current_setting('server_version_num')::int >= 140000) THEN
+        -- PG14-17 has all WAL stats in pg_stat_wal
+        CREATE OR REPLACE FUNCTION @extschema@.snapshot_wal(snapshot_tstamp timestamptz)
+        RETURNS void
+        AS $$
+            INSERT INTO @extschema@.wal (
+                    snapshot_tstamp,
+                    wal_records,
+                    wal_fpi,
+                    wal_bytes,
+                    wal_buffers_full,
+                    wal_write,
+                    wal_sync,
+                    wal_write_time,
+                    wal_sync_time,
+                    stats_reset)
+                SELECT
+                    snapshot_tstamp,
+                    wal_records,
+                    wal_fpi,
+                    wal_bytes,
+                    wal_buffers_full,
+                    wal_write,
+                    wal_sync,
+                    wal_write_time,
+                    wal_sync_time,
+                    stats_reset
+                FROM pg_stat_wal;
+        $$ LANGUAGE SQL;
+    END IF;
+END
+$block$ LANGUAGE PLPGSQL;
+
+
+-- DB
+CREATE TABLE IF NOT EXISTS @extschema@.db(
+    snapshot_tstamp timestamptz REFERENCES @extschema@.snapshots(snapshot_tstamp) ON DELETE CASCADE PRIMARY KEY,
+    xact_commit bigint,
+    xact_rollback bigint,
+    blks_read bigint,
+    blks_hit bigint,
+    tup_returned bigint,
+    tup_fetched bigint,
+    tup_inserted bigint,
+    tup_updated bigint,
+    tup_deleted bigint,
+    temp_files bigint,
+    temp_bytes bigint,
+    block_size int,
+    stats_reset timestamptz,
+    postmaster_start_time timestamptz,
+    checksum_failures bigint,
+    checksum_last_failure timestamptz);
+
+CREATE OR REPLACE FUNCTION @extschema@.snapshot_db(snapshot_tstamp timestamptz)
+RETURNS void
+AS $$
+    INSERT INTO @extschema@.db (
+            snapshot_tstamp,
+            xact_commit,
+            xact_rollback,
+            blks_read,
+            blks_hit,
+            tup_returned,
+            tup_fetched,
+            tup_inserted,
+            tup_updated,
+            tup_deleted,
+            temp_files,
+            temp_bytes,
+            stats_reset,
+            block_size,
+            postmaster_start_time,
+            checksum_failures,
+            checksum_last_failure)
+        SELECT
+            snapshot_tstamp,
+            xact_commit,
+            xact_rollback,
+            blks_read,
+            blks_hit,
+            tup_returned,
+            tup_fetched,
+            tup_inserted,
+            tup_updated,
+            tup_deleted,
+            temp_files,
+            temp_bytes,
+            stats_reset,
+            current_setting('block_size')::int,
+            pg_postmaster_start_time(),
+            checksum_failures,
+            checksum_last_failure
+        FROM pg_stat_database
+        WHERE datname = current_database();
+$$ LANGUAGE SQL;
+
+
+-- I/O
+CREATE TABLE IF NOT EXISTS @extschema@.io(
+    snapshot_tstamp timestamptz REFERENCES @extschema@.snapshots(snapshot_tstamp) ON DELETE CASCADE PRIMARY KEY,
+    io_stats jsonb,
+    stats_reset timestamptz);
+
+-- pg_stat_io only exists in PG16+
+DO $block$
+BEGIN
+    IF (SELECT current_setting('server_version_num')::int >= 180000) THEN
+        -- PG18+ uses byte-based metrics (read_bytes, write_bytes, extend_bytes)
+        CREATE OR REPLACE FUNCTION @extschema@.snapshot_io(snapshot_tstamp timestamptz)
+        RETURNS void
+        AS $$
+            WITH
+                pgsi AS (
+                    SELECT
+                        backend_type,
+                        object,
+                        context,
+                        reads,
+                        read_time,
+                        read_bytes,
+                        writes,
+                        write_time,
+                        write_bytes,
+                        writebacks,
+                        writeback_time,
+                        extends,
+                        extend_time,
+                        extend_bytes,
+                        hits,
+                        evictions,
+                        reuses,
+                        fsyncs,
+                        fsync_time,
+                        stats_reset
+                    FROM pg_stat_io
+                    WHERE NOT (reads = 0 AND writes = 0)),
+                ioagg AS (
+                    SELECT jsonb_agg(io)
+                    FROM (SELECT *
+                          FROM pgsi) io)
+            INSERT INTO @extschema@.io (
+                    snapshot_tstamp,
+                    io_stats,
+                    stats_reset)
+            SELECT snapshot_tstamp,
+                   (SELECT * FROM ioagg) AS io_stats,
+                   (SELECT stats_reset FROM pgsi LIMIT 1) AS stats_reset;
+        $$ LANGUAGE SQL;
+    ELSIF (SELECT current_setting('server_version_num')::int >= 160000) THEN
+        -- PG16-17 uses operation counts without byte metrics
+        CREATE OR REPLACE FUNCTION @extschema@.snapshot_io(snapshot_tstamp timestamptz)
+        RETURNS void
+        AS $$
+            WITH
+                pgsi AS (
+                    SELECT
+                        backend_type,
+                        object,
+                        context,
+                        reads,
+                        read_time,
+                        writes,
+                        write_time,
+                        writebacks,
+                        writeback_time,
+                        extends,
+                        extend_time,
+                        hits,
+                        evictions,
+                        reuses,
+                        fsyncs,
+                        fsync_time,
+                        stats_reset
+                    FROM pg_stat_io
+                    WHERE NOT (reads = 0 AND writes = 0)),
+                ioagg AS (
+                    SELECT jsonb_agg(io)
+                    FROM (SELECT *
+                          FROM pgsi) io)
+            INSERT INTO @extschema@.io (
+                    snapshot_tstamp,
+                    io_stats,
+                    stats_reset)
+            SELECT snapshot_tstamp,
+                   (SELECT * FROM ioagg) AS io_stats,
+                   (SELECT stats_reset FROM pgsi LIMIT 1) AS stats_reset;
+        $$ LANGUAGE SQL;
+    END IF;
+END
+$block$ LANGUAGE PLPGSQL;
+
+
+-- Snapshots
+CREATE OR REPLACE FUNCTION @extschema@.snapshot()
+RETURNS timestamptz
+AS $$
+    DECLARE ts timestamptz;
+    BEGIN
+        ts := clock_timestamp();
+        INSERT INTO @extschema@.snapshots
+        VALUES (ts);
+        PERFORM @extschema@.snapshot_buf(ts);
+        PERFORM @extschema@.snapshot_conf(ts);
+        PERFORM @extschema@.snapshot_conn(ts);
+        PERFORM @extschema@.snapshot_db(ts);
+        -- pg_stat_io only exists in PG16+
+        IF (SELECT current_setting('server_version_num')::int >= 160000) THEN
+            PERFORM @extschema@.snapshot_io(ts);
+        END IF;
+        PERFORM @extschema@.snapshot_lock(ts);
+        PERFORM @extschema@.snapshot_repl(ts);
+        PERFORM @extschema@.snapshot_slru(ts);
+        PERFORM @extschema@.snapshot_wait(ts);
+        -- pg_stat_wal only exists in PG14+
+        IF (SELECT current_setting('server_version_num')::int >= 140000) THEN
+            PERFORM @extschema@.snapshot_wal(ts);
+        END IF;
+        RAISE NOTICE 'created pg_statviz snapshot';
+        RETURN ts;
+    END
+$$ LANGUAGE PLPGSQL;
+
+CREATE OR REPLACE FUNCTION @extschema@.delete_snapshots()
+RETURNS void
+AS $$
+    BEGIN
+        RAISE NOTICE 'truncating table "snapshots"';
+        TRUNCATE @extschema@.snapshots CASCADE;
+    END
+$$ LANGUAGE PLPGSQL;
+
+
+-- Make tables dumpable
+SELECT pg_catalog.pg_extension_config_dump('pgstatviz.buf', '');
+SELECT pg_catalog.pg_extension_config_dump('pgstatviz.conf', '');
+SELECT pg_catalog.pg_extension_config_dump('pgstatviz.conn', '');
+SELECT pg_catalog.pg_extension_config_dump('pgstatviz.db', '');
+SELECT pg_catalog.pg_extension_config_dump('pgstatviz.io', '');
+SELECT pg_catalog.pg_extension_config_dump('pgstatviz.lock', '');
+SELECT pg_catalog.pg_extension_config_dump('pgstatviz.repl', '');
+SELECT pg_catalog.pg_extension_config_dump('pgstatviz.slru', '');
+SELECT pg_catalog.pg_extension_config_dump('pgstatviz.snapshots', '');
+SELECT pg_catalog.pg_extension_config_dump('pgstatviz.wait', '');
+SELECT pg_catalog.pg_extension_config_dump('pgstatviz.wal', '');
+
+
+-- Permissions
+GRANT USAGE ON SCHEMA @extschema@ TO pg_monitor;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA @extschema@ TO pg_monitor;
+GRANT SELECT ON ALL TABLES IN SCHEMA @extschema@ TO pg_monitor;
+GRANT INSERT ON ALL TABLES IN SCHEMA @extschema@ TO pg_monitor;
+GRANT DELETE ON ALL TABLES IN SCHEMA @extschema@ TO pg_monitor;
+GRANT TRUNCATE ON ALL TABLES IN SCHEMA @extschema@ TO pg_monitor;

--- a/pg_statviz.control
+++ b/pg_statviz.control
@@ -1,5 +1,5 @@
 # pg_statviz
 comment = 'stats visualization and time series analysis'
-default_version = '1.1'
+default_version = '1.2'
 schema = pgstatviz
 relocatable = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pg_statviz"
-version = "1.1"
+version = "1.2"
 description = "A minimalist extension and utility pair for time series analysis and visualization of PostgreSQL internal statistics."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -12,11 +12,12 @@ classifiers = ["Development Status :: 5 - Production/Stable",
 dependencies = ["argh<0.30", "contourpy", "cycler", "fonttools", "kiwisolver", "matplotlib", "numpy", "packaging", "pandas", "Pillow", "psycopg", "pyparsing", "python-dateutil", "six"]
 
 [project.optional-dependencies]
-# Opt-in AI analysis. Installs the SDKs for all three --ai providers
-# (Claude via anthropic, Gemini via google-genai, local vision via ollama)
-# so the user can pick any one at runtime without a second install step.
-# None of these are needed for the default chart-generation workflow.
-ai = ["anthropic", "google-genai", "ollama"]
+# Opt-in AI analysis. Installs the SDKs for all four --ai providers (Claude
+# via anthropic, Gemini via google-genai, OpenAI and any OpenAI-compatible
+# endpoint via openai, local vision via ollama) so the user can pick any one
+# at runtime without a second install step. None of these are needed for the
+# default chart-generation workflow.
+ai = ["anthropic", "google-genai", "openai", "ollama"]
 
 [project.urls]
 "Homepage" = "https://github.com/vyruss/pg_statviz"

--- a/src/pg_statviz/libs/ai.py
+++ b/src/pg_statviz/libs/ai.py
@@ -1,9 +1,10 @@
 """
 pg_statviz - stats visualization and time series analysis
 
-AI analysis backend. Provides three provider adapters (Claude / Gemini / local
-Ollama) behind a single synchronous entry point, plus a module-facing helper
-that owns the per-chart ceremony so leaf modules stay focused on charts.
+AI analysis backend. Provides four provider adapters (Claude / Gemini /
+OpenAI-compatible / local Ollama) behind a single synchronous entry point,
+plus a module-facing helper that owns the per-chart ceremony so leaf modules
+stay focused on charts.
 """
 
 __author__ = "Jimmy Angelakos"
@@ -41,6 +42,12 @@ except ImportError:
     GOOGLE_GENAI_AVAILABLE = False
 
 try:
+    import openai
+    OPENAI_AVAILABLE = True
+except ImportError:
+    OPENAI_AVAILABLE = False
+
+try:
     import ollama
     OLLAMA_AVAILABLE = True
 except ImportError:
@@ -48,22 +55,33 @@ except ImportError:
 
 
 # --- Defaults --------------------------------------------------------------
-# All three default models must be vision-capable so they can read the chart
-# PNGs alongside the textual data summary.
-CLAUDE_MODEL = "claude-sonnet-4-6"
-# latest free-tier-eligible Gemini (Apr 2026)
-GEMINI_MODEL = "gemini-2.5-flash"
+# Every default model must be vision-capable so it can read the chart PNGs
+# alongside the textual data summary.
+CLAUDE_MODEL = "claude-sonnet-5"
+# Most capable free-tier-eligible Gemini. The Pro series left the free tier
+# in Apr 2026, so Flash-class is the ceiling.
+GEMINI_MODEL = "gemini-3.7-flash"
 # Gemma 4 E4B: Google's current small vision-capable open model.
 # ~4.5B effective params, vision-capable (reads chart PNGs).
 # Needs ~10 GB VRAM to run fully on GPU; partially offloads to
 # CPU on smaller cards.
 OLLAMA_MODEL = "gemma4:e4b"
+# Cheapest of the current OpenAI frontier family, vision-capable. Any
+# OpenAI-compatible server names its models differently, so OPENAI_MODEL
+# overrides this at runtime.
+OPENAI_MODEL = "gpt-5.6-luna"
 
 # Selectable provider keys exposed on the CLI as `--ai [PROVIDER]`.
 # Imported by every module so the argparse choices list stays in lockstep
 # with the registry.
-AI_PROVIDERS = ('claude', 'gemini', 'local')
+AI_PROVIDERS = ('claude', 'gemini', 'openai', 'local')
 DEFAULT_AI_PROVIDER = 'claude'
+
+# Shared --ai help string. Lives here so the provider list is described in
+# one place rather than in all fifteen module argparse decorators.
+AI_HELP = ("enable AI analysis (default provider: " + DEFAULT_AI_PROVIDER
+           + "). Choices: claude (Anthropic), gemini (Google), "
+             "openai (OpenAI/compatible), local (Ollama).")
 
 ANTHROPIC_INSTALL_GUIDE = """
 AI analysis with --ai claude (default) requires the Anthropic Python SDK and
@@ -89,10 +107,39 @@ Google AI Studio API key (free tier). Setup:
    (or: pip install google-genai)
 
 2. Get an API key at https://aistudio.google.com/apikey
-   (Free tier covers gemini-2.5-flash and other 2.5-series models.)
+   (Free tier covers gemini-3.7-flash and the other Flash models.)
 
 3. Export it before running pg_statviz:
    export GOOGLE_API_KEY=...
+"""
+
+OPENAI_INSTALL_GUIDE = f"""
+AI analysis with --ai openai requires the OpenAI Python SDK and an endpoint
+that speaks the OpenAI chat completions API. Setup:
+
+1. Install the AI extras:
+   pip install pg_statviz[ai]
+   (or: pip install openai)
+
+2. Point it at an endpoint:
+
+   OpenAI itself -- get a key at https://platform.openai.com/api-keys
+
+     export OPENAI_API_KEY=sk-...
+
+   Any OpenAI-compatible server (vLLM, LM Studio, llama.cpp, Ollama's
+   /v1 endpoint, OpenRouter, Groq, ...) -- set the base URL too. Servers
+   that don't check the key still need it set to something:
+
+     export OPENAI_BASE_URL=http://localhost:8000/v1
+     export OPENAI_API_KEY=unused
+
+3. Optionally pick the model (default: {OPENAI_MODEL}). Required for
+   compatible servers, whose model names are their own:
+
+     export OPENAI_MODEL=Qwen/Qwen3-VL-8B-Instruct
+
+   The model must be vision-capable to read the chart images.
 """
 
 OLLAMA_INSTALL_GUIDE = f"""
@@ -514,6 +561,67 @@ def _analyze_gemini(df: pd.DataFrame, module_name: str,
         return None
 
 
+def _openai_client():
+    """Build an OpenAI SDK client.
+
+    The SDK reads OPENAI_API_KEY and OPENAI_BASE_URL from the environment
+    itself, so pointing pg_statviz at a compatible server needs no code
+    path of its own. Wrapped in a function purely so tests can substitute
+    a stand-in client.
+    """
+    return openai.OpenAI()
+
+
+def _openai_messages(system_prompt: str, user_text: str,
+                     image_paths=None) -> list:
+    """Build the chat-completions message list.
+
+    Images are inlined as base64 data URLs in the image_url content part,
+    which is the shape every OpenAI-compatible server implements. Images
+    lead and text trails, matching the other providers.
+    """
+    content = [{
+        "type": "image_url",
+        "image_url": {
+            "url": "data:image/png;base64,"
+                   + base64.standard_b64encode(img).decode("ascii"),
+        },
+    } for img in _read_images(image_paths)]
+    content.append({"type": "text", "text": user_text})
+    return [{"role": "system", "content": system_prompt},
+            {"role": "user", "content": content}]
+
+
+def _analyze_openai(df: pd.DataFrame, module_name: str,
+                    metric_description: str,
+                    image_paths, info: dict | None = None,
+                    settings: dict | None = None,
+                    findings: list | None = None) -> str | None:
+    """Run analysis via OpenAI or any OpenAI-compatible chat endpoint."""
+    if not OPENAI_AVAILABLE:
+        _logger.warning("openai package not installed."
+                        + OPENAI_INSTALL_GUIDE)
+        return None
+    if not os.environ.get("OPENAI_API_KEY"):
+        _logger.error("OPENAI_API_KEY env var is not set."
+                      + OPENAI_INSTALL_GUIDE)
+        return None
+
+    user_text = _build_user_text(module_name, metric_description, df,
+                                 info, settings, findings)
+    try:
+        with _timed("OpenAI"):
+            response = _openai_client().chat.completions.create(
+                model=os.environ.get("OPENAI_MODEL", OPENAI_MODEL),
+                messages=_openai_messages(SYSTEM_PROMPT, user_text,
+                                          image_paths),
+            )
+        return response.choices[0].message.content
+    except Exception as e:
+        _log_provider_error("OpenAI", "OPENAI_API_KEY", e)
+        return None
+
+
 def _analyze_local(df: pd.DataFrame, module_name: str,
                    metric_description: str,
                    image_paths, info: dict | None = None,
@@ -577,6 +685,13 @@ _PROVIDERS = {
         'install_guide': GEMINI_INSTALL_GUIDE,
         'sdk_pkg': 'google-genai',
         'label': 'Gemini',
+    },
+    'openai': {
+        'fn': _analyze_openai,
+        'available': lambda: OPENAI_AVAILABLE,
+        'install_guide': OPENAI_INSTALL_GUIDE,
+        'sdk_pkg': 'openai',
+        'label': 'OpenAI',
     },
     'local': {
         'fn': _analyze_local,
@@ -714,6 +829,21 @@ def _chat_gemini(system_prompt: str, user_text: str) -> str | None:
         return None
 
 
+def _chat_openai(system_prompt: str, user_text: str) -> str | None:
+    if not OPENAI_AVAILABLE or not os.environ.get("OPENAI_API_KEY"):
+        return None
+    try:
+        with _timed("OpenAI overview"):
+            r = _openai_client().chat.completions.create(
+                model=os.environ.get("OPENAI_MODEL", OPENAI_MODEL),
+                messages=_openai_messages(system_prompt, user_text),
+            )
+        return r.choices[0].message.content
+    except Exception as e:
+        _log_provider_error("OpenAI", "OPENAI_API_KEY", e)
+        return None
+
+
 def _chat_local(system_prompt: str, user_text: str) -> str | None:
     if not OLLAMA_AVAILABLE:
         return None
@@ -734,6 +864,7 @@ def _chat_local(system_prompt: str, user_text: str) -> str | None:
 _CHAT_PROVIDERS = {
     'claude': _chat_claude,
     'gemini': _chat_gemini,
+    'openai': _chat_openai,
     'local': _chat_local,
 }
 

--- a/src/pg_statviz/modules/analyze.py
+++ b/src/pg_statviz/modules/analyze.py
@@ -9,7 +9,8 @@ __license__ = "PostgreSQL License"
 import getpass
 import logging
 from argh.decorators import arg
-from pg_statviz.libs.ai import AI_PROVIDERS, DEFAULT_AI_PROVIDER
+from pg_statviz.libs.ai import (AI_HELP, AI_PROVIDERS,
+                                DEFAULT_AI_PROVIDER)
 from pg_statviz.modules.buf import buf
 from pg_statviz.modules.cache import cache
 from pg_statviz.modules.checkp import checkp
@@ -40,11 +41,9 @@ from pg_statviz.libs.info import getinfo
      help="date range to be analyzed in ISO 8601 format e.g. 2026-01-01T00:00 "
           + "2026-01-01T23:59")
 @arg('-O', '--outputdir', help="output directory")
-@arg('-A', '--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
+@arg('--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
      choices=AI_PROVIDERS, metavar='PROVIDER',
-     help="enable AI analysis (default provider: " + DEFAULT_AI_PROVIDER
-          + "). Choices: claude (Anthropic), gemini (Google AI Studio), "
-            "local (Ollama vision model).")
+     help=AI_HELP)
 def analyze(*, dbname=getpass.getuser(), host="/var/run/postgresql",
             port="5432", username=getpass.getuser(), password=None,
             daterange=[], outputdir=None, ai=None):

--- a/src/pg_statviz/modules/buf.py
+++ b/src/pg_statviz/modules/buf.py
@@ -16,7 +16,8 @@ from matplotlib.pyplot import close as mpclose
 from matplotlib.ticker import MaxNLocator
 from pandas import DataFrame
 from pg_statviz.libs import plot
-from pg_statviz.libs.ai import (AI_PROVIDERS, DEFAULT_AI_PROVIDER,
+from pg_statviz.libs.ai import (AI_HELP, AI_PROVIDERS,
+                                DEFAULT_AI_PROVIDER,
                                 run_chart_analysis)
 from pg_statviz.libs.dbconn import dbconn
 from pg_statviz.libs.html_report import finalize_module_report
@@ -34,11 +35,9 @@ from pg_statviz.libs.info import getinfo, get_settings
      help="date range to be analyzed in ISO 8601 format e.g. 2026-01-01T00:00 "
           + "2026-01-01T23:59")
 @arg('-O', '--outputdir', help="output directory")
-@arg('-A', '--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
+@arg('--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
      choices=AI_PROVIDERS, metavar='PROVIDER',
-     help="enable AI analysis (default provider: " + DEFAULT_AI_PROVIDER
-          + "). Choices: claude (Anthropic), gemini (Google AI Studio), "
-            "local (Ollama vision model).")
+     help=AI_HELP)
 @arg('--info', help=argparse.SUPPRESS)
 @arg('--conn', help=argparse.SUPPRESS)
 def buf(*, dbname=getpass.getuser(), host="/var/run/postgresql", port="5432",

--- a/src/pg_statviz/modules/cache.py
+++ b/src/pg_statviz/modules/cache.py
@@ -13,7 +13,8 @@ from argh.decorators import arg
 from dateutil.parser import isoparse
 from matplotlib.pyplot import close as mpclose
 from pg_statviz.libs import plot
-from pg_statviz.libs.ai import (AI_PROVIDERS, DEFAULT_AI_PROVIDER,
+from pg_statviz.libs.ai import (AI_HELP, AI_PROVIDERS,
+                                DEFAULT_AI_PROVIDER,
                                 run_chart_analysis)
 from pg_statviz.libs.dbconn import dbconn
 from pg_statviz.libs.html_report import finalize_module_report
@@ -33,11 +34,9 @@ from pandas import DataFrame
      help="date range to be analyzed in ISO 8601 format e.g. 2026-01-01T00:00 "
           + "2026-01-01T23:59")
 @arg('-O', '--outputdir', help="output directory")
-@arg('-A', '--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
+@arg('--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
      choices=AI_PROVIDERS, metavar='PROVIDER',
-     help="enable AI analysis (default provider: " + DEFAULT_AI_PROVIDER
-          + "). Choices: claude (Anthropic), gemini (Google AI Studio), "
-            "local (Ollama vision model).")
+     help=AI_HELP)
 @arg('--info', help=argparse.SUPPRESS)
 @arg('--conn', help=argparse.SUPPRESS)
 def cache(*, dbname=getpass.getuser(), host="/var/run/postgresql", port="5432",

--- a/src/pg_statviz/modules/checkp.py
+++ b/src/pg_statviz/modules/checkp.py
@@ -16,7 +16,8 @@ from matplotlib.pyplot import close as mpclose
 from matplotlib.ticker import MaxNLocator
 from pandas import DataFrame
 from pg_statviz.libs import plot
-from pg_statviz.libs.ai import (AI_PROVIDERS, DEFAULT_AI_PROVIDER,
+from pg_statviz.libs.ai import (AI_HELP, AI_PROVIDERS,
+                                DEFAULT_AI_PROVIDER,
                                 run_chart_analysis)
 from pg_statviz.libs.dbconn import dbconn
 from pg_statviz.libs.html_report import finalize_module_report
@@ -34,11 +35,9 @@ from pg_statviz.libs.info import getinfo, get_settings
      help="date range to be analyzed in ISO 8601 format e.g. 2026-01-01T00:00 "
           + "2026-01-01T23:59")
 @arg('-O', '--outputdir', help="output directory")
-@arg('-A', '--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
+@arg('--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
      choices=AI_PROVIDERS, metavar='PROVIDER',
-     help="enable AI analysis (default provider: " + DEFAULT_AI_PROVIDER
-          + "). Choices: claude (Anthropic), gemini (Google AI Studio), "
-            "local (Ollama vision model).")
+     help=AI_HELP)
 @arg('--info', help=argparse.SUPPRESS)
 @arg('--conn', help=argparse.SUPPRESS)
 def checkp(*, dbname=getpass.getuser(), host="/var/run/postgresql",

--- a/src/pg_statviz/modules/checksum.py
+++ b/src/pg_statviz/modules/checksum.py
@@ -15,7 +15,8 @@ from matplotlib.pyplot import close as mpclose
 from matplotlib.ticker import MaxNLocator
 from pandas import DataFrame
 from pg_statviz.libs import plot
-from pg_statviz.libs.ai import (AI_PROVIDERS, DEFAULT_AI_PROVIDER,
+from pg_statviz.libs.ai import (AI_HELP, AI_PROVIDERS,
+                                DEFAULT_AI_PROVIDER,
                                 run_chart_analysis)
 from pg_statviz.libs.dbconn import dbconn
 from pg_statviz.libs.html_report import finalize_module_report
@@ -33,11 +34,9 @@ from pg_statviz.libs.info import getinfo
      help="date range to be analyzed in ISO 8601 format e.g. "
           + "2026-01-01T00:00 2026-01-01T23:59")
 @arg('-O', '--outputdir', help="output directory")
-@arg('-A', '--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
+@arg('--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
      choices=AI_PROVIDERS, metavar='PROVIDER',
-     help="enable AI analysis (default provider: " + DEFAULT_AI_PROVIDER
-          + "). Choices: claude (Anthropic), gemini (Google AI Studio), "
-            "local (Ollama vision model).")
+     help=AI_HELP)
 @arg('--info', help=argparse.SUPPRESS)
 @arg('--conn', help=argparse.SUPPRESS)
 def checksum(*, dbname=getpass.getuser(), host="/var/run/postgresql",

--- a/src/pg_statviz/modules/conf.py
+++ b/src/pg_statviz/modules/conf.py
@@ -13,7 +13,8 @@ from argh.decorators import arg
 from dateutil.parser import isoparse
 from matplotlib.pyplot import close as mpclose
 from pg_statviz.libs import plot
-from pg_statviz.libs.ai import (AI_PROVIDERS, DEFAULT_AI_PROVIDER,
+from pg_statviz.libs.ai import (AI_HELP, AI_PROVIDERS,
+                                DEFAULT_AI_PROVIDER,
                                 run_chart_analysis)
 from pg_statviz.libs.dbconn import dbconn
 from pg_statviz.libs.html_report import finalize_module_report
@@ -46,11 +47,9 @@ def get_config_diff(prev_conf, curr_conf):
      help="date range to be analyzed in ISO 8601 format e.g. 2026-01-01T00:00"
           + " 2026-01-01T23:59")
 @arg('-O', '--outputdir', help="output directory")
-@arg('-A', '--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
+@arg('--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
      choices=AI_PROVIDERS, metavar='PROVIDER',
-     help="enable AI analysis (default provider: " + DEFAULT_AI_PROVIDER
-          + "). Choices: claude (Anthropic), gemini (Google AI Studio), "
-            "local (Ollama vision model).")
+     help=AI_HELP)
 @arg('--info', help=argparse.SUPPRESS)
 @arg('--conn', help=argparse.SUPPRESS)
 def conf(*, dbname=getpass.getuser(), host="/var/run/postgresql", port="5432",

--- a/src/pg_statviz/modules/conn.py
+++ b/src/pg_statviz/modules/conn.py
@@ -15,7 +15,8 @@ from matplotlib.pyplot import close as mpclose
 from matplotlib.ticker import MaxNLocator
 from pandas import DataFrame
 from pg_statviz.libs import plot
-from pg_statviz.libs.ai import (AI_PROVIDERS, DEFAULT_AI_PROVIDER,
+from pg_statviz.libs.ai import (AI_HELP, AI_PROVIDERS,
+                                DEFAULT_AI_PROVIDER,
                                 run_chart_analysis)
 from pg_statviz.libs.dbconn import dbconn
 from pg_statviz.libs.html_report import finalize_module_report
@@ -33,11 +34,9 @@ from pg_statviz.libs.info import getinfo, get_settings
      help="date range to be analyzed in ISO 8601 format e.g. 2026-01-01T00:00"
           + " 2026-01-01T23:59")
 @arg('-O', '--outputdir', help="output directory")
-@arg('-A', '--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
+@arg('--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
      choices=AI_PROVIDERS, metavar='PROVIDER',
-     help="enable AI analysis (default provider: " + DEFAULT_AI_PROVIDER
-          + "). Choices: claude (Anthropic), gemini (Google AI Studio), "
-            "local (Ollama vision model).")
+     help=AI_HELP)
 @arg('--info', help=argparse.SUPPRESS)
 @arg('--conn', help=argparse.SUPPRESS)
 @arg('-u', '--users', help="user name(s) to plot in analysis",

--- a/src/pg_statviz/modules/io.py
+++ b/src/pg_statviz/modules/io.py
@@ -16,7 +16,8 @@ from matplotlib.pyplot import close as mpclose
 from matplotlib.ticker import MaxNLocator
 from pandas import DataFrame
 from pg_statviz.libs import plot
-from pg_statviz.libs.ai import (AI_PROVIDERS, DEFAULT_AI_PROVIDER,
+from pg_statviz.libs.ai import (AI_HELP, AI_PROVIDERS,
+                                DEFAULT_AI_PROVIDER,
                                 run_chart_analysis)
 from pg_statviz.libs.dbconn import dbconn
 from pg_statviz.libs.html_report import finalize_module_report
@@ -34,11 +35,9 @@ from pg_statviz.libs.info import getinfo
      help="date range to be analyzed in ISO 8601 format e.g. 2026-01-01T00:00"
           + " 2026-01-01T23:59")
 @arg('-O', '--outputdir', help="output directory")
-@arg('-A', '--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
+@arg('--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
      choices=AI_PROVIDERS, metavar='PROVIDER',
-     help="enable AI analysis (default provider: " + DEFAULT_AI_PROVIDER
-          + "). Choices: claude (Anthropic), gemini (Google AI Studio), "
-            "local (Ollama vision model).")
+     help=AI_HELP)
 @arg('--info', help=argparse.SUPPRESS)
 @arg('--conn', help=argparse.SUPPRESS)
 def io(*, dbname=getpass.getuser(), host="/var/run/postgresql", port="5432",

--- a/src/pg_statviz/modules/lock.py
+++ b/src/pg_statviz/modules/lock.py
@@ -15,7 +15,8 @@ from matplotlib.pyplot import close as mpclose
 from matplotlib.ticker import MaxNLocator
 from pandas import DataFrame
 from pg_statviz.libs import plot
-from pg_statviz.libs.ai import (AI_PROVIDERS, DEFAULT_AI_PROVIDER,
+from pg_statviz.libs.ai import (AI_HELP, AI_PROVIDERS,
+                                DEFAULT_AI_PROVIDER,
                                 run_chart_analysis)
 from pg_statviz.libs.dbconn import dbconn
 from pg_statviz.libs.html_report import finalize_module_report
@@ -33,11 +34,9 @@ from pg_statviz.libs.info import getinfo
      help="date range to be analyzed in ISO 8601 format e.g. 2026-01-01T00:00"
           + " 2026-01-01T23:59")
 @arg('-O', '--outputdir', help="output directory")
-@arg('-A', '--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
+@arg('--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
      choices=AI_PROVIDERS, metavar='PROVIDER',
-     help="enable AI analysis (default provider: " + DEFAULT_AI_PROVIDER
-          + "). Choices: claude (Anthropic), gemini (Google AI Studio), "
-            "local (Ollama vision model).")
+     help=AI_HELP)
 @arg('--info', help=argparse.SUPPRESS)
 @arg('--conn', help=argparse.SUPPRESS)
 def lock(*, dbname=getpass.getuser(), host="/var/run/postgresql", port="5432",

--- a/src/pg_statviz/modules/repl.py
+++ b/src/pg_statviz/modules/repl.py
@@ -14,7 +14,8 @@ from dateutil.parser import isoparse
 from matplotlib.pyplot import close as mpclose
 from pandas import DataFrame
 from pg_statviz.libs import plot
-from pg_statviz.libs.ai import (AI_PROVIDERS, DEFAULT_AI_PROVIDER,
+from pg_statviz.libs.ai import (AI_HELP, AI_PROVIDERS,
+                                DEFAULT_AI_PROVIDER,
                                 run_chart_analysis)
 from pg_statviz.libs.dbconn import dbconn
 from pg_statviz.libs.html_report import finalize_module_report
@@ -32,11 +33,9 @@ from pg_statviz.libs.info import getinfo, get_settings
      help="date range to be analyzed in ISO 8601 format e.g. 2026-01-01T00:00"
           + " 2026-01-01T23:59")
 @arg('-O', '--outputdir', help="output directory")
-@arg('-A', '--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
+@arg('--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
      choices=AI_PROVIDERS, metavar='PROVIDER',
-     help="enable AI analysis (default provider: " + DEFAULT_AI_PROVIDER
-          + "). Choices: claude (Anthropic), gemini (Google AI Studio), "
-            "local (Ollama vision model).")
+     help=AI_HELP)
 @arg('--info', help=argparse.SUPPRESS)
 @arg('--conn', help=argparse.SUPPRESS)
 def repl(*, dbname=getpass.getuser(), host="/var/run/postgresql", port="5432",

--- a/src/pg_statviz/modules/slru.py
+++ b/src/pg_statviz/modules/slru.py
@@ -14,7 +14,8 @@ from dateutil.parser import isoparse
 from matplotlib.pyplot import close as mpclose
 from pandas import DataFrame
 from pg_statviz.libs import plot
-from pg_statviz.libs.ai import (AI_PROVIDERS, DEFAULT_AI_PROVIDER,
+from pg_statviz.libs.ai import (AI_HELP, AI_PROVIDERS,
+                                DEFAULT_AI_PROVIDER,
                                 run_chart_analysis)
 from pg_statviz.libs.dbconn import dbconn
 from pg_statviz.libs.html_report import finalize_module_report
@@ -32,11 +33,9 @@ from pg_statviz.libs.info import getinfo
      help="date range to be analyzed in ISO 8601 format e.g. 2026-01-01T00:00"
           + " 2026-01-01T23:59")
 @arg('-O', '--outputdir', help="output directory")
-@arg('-A', '--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
+@arg('--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
      choices=AI_PROVIDERS, metavar='PROVIDER',
-     help="enable AI analysis (default provider: " + DEFAULT_AI_PROVIDER
-          + "). Choices: claude (Anthropic), gemini (Google AI Studio), "
-            "local (Ollama vision model).")
+     help=AI_HELP)
 @arg('--info', help=argparse.SUPPRESS)
 @arg('--conn', help=argparse.SUPPRESS)
 def slru(*, dbname=getpass.getuser(), host="/var/run/postgresql", port="5432",

--- a/src/pg_statviz/modules/tuple.py
+++ b/src/pg_statviz/modules/tuple.py
@@ -15,7 +15,8 @@ from dateutil.parser import isoparse
 from matplotlib.pyplot import close as mpclose
 from pandas import DataFrame
 from pg_statviz.libs import plot
-from pg_statviz.libs.ai import (AI_PROVIDERS, DEFAULT_AI_PROVIDER,
+from pg_statviz.libs.ai import (AI_HELP, AI_PROVIDERS,
+                                DEFAULT_AI_PROVIDER,
                                 run_chart_analysis)
 from pg_statviz.libs.dbconn import dbconn
 from pg_statviz.libs.html_report import finalize_module_report
@@ -33,11 +34,9 @@ from pg_statviz.libs.info import getinfo, get_settings
      help="date range to be analyzed in ISO 8601 format e.g. 2026-01-01T00:00 "
           + "2026-01-01T23:59")
 @arg('-O', '--outputdir', help="output directory")
-@arg('-A', '--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
+@arg('--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
      choices=AI_PROVIDERS, metavar='PROVIDER',
-     help="enable AI analysis (default provider: " + DEFAULT_AI_PROVIDER
-          + "). Choices: claude (Anthropic), gemini (Google AI Studio), "
-            "local (Ollama vision model).")
+     help=AI_HELP)
 @arg('--info', help=argparse.SUPPRESS)
 @arg('--conn', help=argparse.SUPPRESS)
 def tuple(*, dbname=getpass.getuser(), host="/var/run/postgresql", port="5432",

--- a/src/pg_statviz/modules/wait.py
+++ b/src/pg_statviz/modules/wait.py
@@ -15,7 +15,8 @@ from matplotlib.pyplot import close as mpclose
 from matplotlib.ticker import MaxNLocator
 from pandas import DataFrame
 from pg_statviz.libs import plot
-from pg_statviz.libs.ai import (AI_PROVIDERS, DEFAULT_AI_PROVIDER,
+from pg_statviz.libs.ai import (AI_HELP, AI_PROVIDERS,
+                                DEFAULT_AI_PROVIDER,
                                 run_chart_analysis)
 from pg_statviz.libs.dbconn import dbconn
 from pg_statviz.libs.html_report import finalize_module_report
@@ -33,11 +34,9 @@ from pg_statviz.libs.info import getinfo
      help="date range to be analyzed in ISO 8601 format e.g. 2026-01-01T00:00"
           + " 2026-01-01T23:59")
 @arg('-O', '--outputdir', help="output directory")
-@arg('-A', '--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
+@arg('--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
      choices=AI_PROVIDERS, metavar='PROVIDER',
-     help="enable AI analysis (default provider: " + DEFAULT_AI_PROVIDER
-          + "). Choices: claude (Anthropic), gemini (Google AI Studio), "
-            "local (Ollama vision model).")
+     help=AI_HELP)
 @arg('--info', help=argparse.SUPPRESS)
 @arg('--conn', help=argparse.SUPPRESS)
 def wait(*, dbname=getpass.getuser(), host="/var/run/postgresql", port="5432",

--- a/src/pg_statviz/modules/wal.py
+++ b/src/pg_statviz/modules/wal.py
@@ -16,7 +16,8 @@ from matplotlib.pyplot import close as mpclose
 from matplotlib.ticker import MaxNLocator
 from pandas import DataFrame
 from pg_statviz.libs import plot
-from pg_statviz.libs.ai import (AI_PROVIDERS, DEFAULT_AI_PROVIDER,
+from pg_statviz.libs.ai import (AI_HELP, AI_PROVIDERS,
+                                DEFAULT_AI_PROVIDER,
                                 run_chart_analysis)
 from pg_statviz.libs.dbconn import dbconn
 from pg_statviz.libs.html_report import finalize_module_report
@@ -34,11 +35,9 @@ from pg_statviz.libs.info import getinfo, get_settings
      help="date range to be analyzed in ISO 8601 format e.g. 2026-01-01T00:00 "
           + "2026-01-01T23:59")
 @arg('-O', '--outputdir', help="output directory")
-@arg('-A', '--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
+@arg('--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
      choices=AI_PROVIDERS, metavar='PROVIDER',
-     help="enable AI analysis (default provider: " + DEFAULT_AI_PROVIDER
-          + "). Choices: claude (Anthropic), gemini (Google AI Studio), "
-            "local (Ollama vision model).")
+     help=AI_HELP)
 @arg('--info', help=argparse.SUPPRESS)
 @arg('--conn', help=argparse.SUPPRESS)
 def wal(*, dbname=getpass.getuser(), host="/var/run/postgresql", port="5432",

--- a/src/pg_statviz/modules/xact.py
+++ b/src/pg_statviz/modules/xact.py
@@ -16,7 +16,8 @@ from matplotlib.pyplot import close as mpclose
 from matplotlib.ticker import MaxNLocator
 from pandas import DataFrame
 from pg_statviz.libs import plot
-from pg_statviz.libs.ai import (AI_PROVIDERS, DEFAULT_AI_PROVIDER,
+from pg_statviz.libs.ai import (AI_HELP, AI_PROVIDERS,
+                                DEFAULT_AI_PROVIDER,
                                 run_chart_analysis)
 from pg_statviz.libs.dbconn import dbconn
 from pg_statviz.libs.html_report import finalize_module_report
@@ -34,11 +35,9 @@ from pg_statviz.libs.info import getinfo
      help="date range to be analyzed in ISO 8601 format e.g. 2026-01-01T00:00 "
           + "2026-01-01T23:59")
 @arg('-O', '--outputdir', help="output directory")
-@arg('-A', '--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
+@arg('--ai', nargs='?', const=DEFAULT_AI_PROVIDER, default=None,
      choices=AI_PROVIDERS, metavar='PROVIDER',
-     help="enable AI analysis (default provider: " + DEFAULT_AI_PROVIDER
-          + "). Choices: claude (Anthropic), gemini (Google AI Studio), "
-            "local (Ollama vision model).")
+     help=AI_HELP)
 @arg('--info', help=argparse.SUPPRESS)
 @arg('--conn', help=argparse.SUPPRESS)
 def xact(*, dbname=getpass.getuser(), host="/var/run/postgresql", port="5432",

--- a/src/pg_statviz/pg_statviz.py
+++ b/src/pg_statviz/pg_statviz.py
@@ -6,10 +6,11 @@ pg_statviz - stats visualization and time series analysis
 __author__ = "Jimmy Angelakos"
 __copyright__ = "Copyright (c) 2026 Jimmy Angelakos"
 __license__ = "PostgreSQL License"
-__version__ = "1.1"
+__version__ = "1.2"
 
 import sys
 from argh import ArghParser
+from argh.utils import get_subparsers
 from pg_statviz.modules.analyze import analyze
 from pg_statviz.modules.buf import buf
 from pg_statviz.modules.cache import cache
@@ -32,15 +33,24 @@ if sys.version_info < (3, 11):
     raise SystemExit("This program requires Python 3.11 or later")
 
 
+HELP_FLAGS = ('-?', '--help')
+HELP_TEXT = "show this help, then exit"
+
+
 def main():
-    # CLI parser
+    # CLI parser. add_help is off at both levels so that -h stays free for
+    # --host, as in psql and the other PostgreSQL client tools; they expose
+    # help as -? / --help instead.
     p = ArghParser(add_help=False)
-    p.add_argument("--help", action="help")
+    p.add_argument(*HELP_FLAGS, action='help', help=HELP_TEXT)
     p.add_argument('--version', action='version',
                    version=f"pg_statviz {__version__}")
 
     p.add_commands([analyze, buf, cache, checkp, checksum, conf, conn, io,
-                    lock, repl, slru, tuple, wait, wal, xact])
+                    lock, repl, slru, tuple, wait, wal, xact],
+                   func_kwargs={'add_help': False})
+    for subparser in get_subparsers(p).choices.values():
+        subparser.add_argument(*HELP_FLAGS, action='help', help=HELP_TEXT)
     p.set_default_command(analyze)
     p.dispatch()
 

--- a/src/pg_statviz/tests/test_ai.py
+++ b/src/pg_statviz/tests/test_ai.py
@@ -16,7 +16,8 @@ def test_default_ai_provider_is_registered():
 @pytest.fixture
 def clean_env(monkeypatch):
     """Remove any AI API keys that may leak in from the shell environment."""
-    for k in ('ANTHROPIC_API_KEY', 'GOOGLE_API_KEY', 'GEMINI_API_KEY'):
+    for k in ('ANTHROPIC_API_KEY', 'GOOGLE_API_KEY', 'GEMINI_API_KEY',
+              'OPENAI_API_KEY'):
         monkeypatch.delenv(k, raising=False)
 
 
@@ -77,7 +78,8 @@ def test_analyze_stats_dispatches_via_registry(tiny_df, monkeypatch,
     calls = []
 
     def fake_adapter(label):
-        def _fn(df, module_name, metric_description, image_paths):
+        def _fn(df, module_name, metric_description, image_paths,
+                info=None, settings=None, findings=None):
             calls.append(label)
             return f"{label}:ok"
         return _fn
@@ -90,6 +92,10 @@ def test_analyze_stats_dispatches_via_registry(tiny_df, monkeypatch,
         **ai._PROVIDERS['gemini'], 'fn': fake_adapter('gemini'),
         'available': lambda: True,
     })
+    monkeypatch.setitem(ai._PROVIDERS, 'openai', {
+        **ai._PROVIDERS['openai'], 'fn': fake_adapter('openai'),
+        'available': lambda: True,
+    })
     monkeypatch.setitem(ai._PROVIDERS, 'local', {
         **ai._PROVIDERS['local'], 'fn': fake_adapter('local'),
         'available': lambda: True,
@@ -97,14 +103,16 @@ def test_analyze_stats_dispatches_via_registry(tiny_df, monkeypatch,
 
     assert ai.analyze_stats(tiny_df, "M", mode='claude') == "claude:ok"
     assert ai.analyze_stats(tiny_df, "M", mode='gemini') == "gemini:ok"
+    assert ai.analyze_stats(tiny_df, "M", mode='openai') == "openai:ok"
     assert ai.analyze_stats(tiny_df, "M", mode='local') == "local:ok"
-    assert calls == ['claude', 'gemini', 'local']
+    assert calls == ['claude', 'gemini', 'openai', 'local']
 
 
 def test_analyze_stats_adapter_crash_returns_none(tiny_df, monkeypatch):
     # Defence-in-depth: if a future adapter forgets to catch its own
     # exceptions, analyze_stats still returns None (never raises).
-    def exploding(df, module_name, metric_description, image_paths):
+    def exploding(df, module_name, metric_description, image_paths,
+                  info=None, settings=None, findings=None):
         raise RuntimeError("boom")
 
     monkeypatch.setitem(ai._PROVIDERS, 'claude', {
@@ -195,3 +203,161 @@ def test_log_provider_error_generic_message(caplog):
                            Exception("something unexpected"))
     assert any("TestProv" in r.message and "something unexpected" in r.message
                for r in caplog.records)
+
+
+# --- OpenAI-compatible provider -------------------------------------------
+# Hand-rolled stand-ins for the openai SDK surface we touch. Keeping them
+# local to the test file means no mock framework and no SDK install needed.
+
+class MockOpenAIMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class MockOpenAIChoice:
+    def __init__(self, content):
+        self.message = MockOpenAIMessage(content)
+
+
+class MockOpenAIResponse:
+    def __init__(self, content):
+        self.choices = [MockOpenAIChoice(content)]
+
+
+class MockOpenAICompletions:
+    def __init__(self, parent):
+        self.parent = parent
+
+    def create(self, **kwargs):
+        self.parent.calls.append(kwargs)
+        if self.parent.raises:
+            raise self.parent.raises
+        return MockOpenAIResponse("**[HEALTHY]** all good")
+
+
+class MockOpenAIClient:
+    """Mimics openai.OpenAI(): client.chat.completions.create(...)."""
+
+    def __init__(self, raises=None, **init_kwargs):
+        self.calls = []
+        self.init_kwargs = init_kwargs
+        self.raises = raises
+        self.chat = type('chat', (), {})()
+        self.chat.completions = MockOpenAICompletions(self)
+
+
+@pytest.fixture
+def openai_env(monkeypatch):
+    """Pretend the SDK is installed and a key is set."""
+    monkeypatch.setattr(ai, 'OPENAI_AVAILABLE', True)
+    monkeypatch.setenv('OPENAI_API_KEY', 'sk-test')
+    monkeypatch.delenv('OPENAI_BASE_URL', raising=False)
+    monkeypatch.delenv('OPENAI_MODEL', raising=False)
+
+
+@pytest.fixture
+def openai_client(monkeypatch, openai_env):
+    """Install a mock client factory and hand the instance back."""
+    holder = {}
+
+    def factory(**kwargs):
+        holder['client'] = MockOpenAIClient(**kwargs)
+        return holder['client']
+
+    monkeypatch.setattr(ai, '_openai_client', factory)
+    return holder
+
+
+def test_openai_is_a_registered_provider():
+    assert 'openai' in ai.AI_PROVIDERS
+    assert 'openai' in ai._PROVIDERS
+
+
+def test_chat_providers_match_analysis_providers():
+    # Overview synthesis must cover exactly the same provider set as
+    # per-chart analysis, or --ai <p> would work per module and silently
+    # skip the executive summary.
+    assert set(ai._CHAT_PROVIDERS) == set(ai._PROVIDERS)
+
+
+def test_analyze_openai_returns_none_without_sdk(tiny_df, monkeypatch):
+    monkeypatch.setattr(ai, 'OPENAI_AVAILABLE', False)
+    assert ai._analyze_openai(tiny_df, "M", "desc", None) is None
+
+
+def test_analyze_openai_returns_none_without_key(tiny_df, monkeypatch):
+    monkeypatch.setattr(ai, 'OPENAI_AVAILABLE', True)
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    assert ai._analyze_openai(tiny_df, "M", "desc", None) is None
+
+
+def test_analyze_openai_returns_completion_text(tiny_df, openai_client):
+    out = ai._analyze_openai(tiny_df, "M", "desc", None)
+    assert out == "**[HEALTHY]** all good"
+
+
+def test_analyze_openai_uses_default_model(tiny_df, openai_client):
+    ai._analyze_openai(tiny_df, "M", "desc", None)
+    assert openai_client['client'].calls[0]['model'] == ai.OPENAI_MODEL
+
+
+def test_analyze_openai_model_env_override(tiny_df, openai_client,
+                                           monkeypatch):
+    # OpenAI-compatible servers each expose their own model names, so the
+    # model must be overridable without a code change.
+    monkeypatch.setenv('OPENAI_MODEL', 'my-local-vlm')
+    ai._analyze_openai(tiny_df, "M", "desc", None)
+    assert openai_client['client'].calls[0]['model'] == 'my-local-vlm'
+
+
+def test_analyze_openai_sends_system_and_user_messages(tiny_df,
+                                                       openai_client):
+    ai._analyze_openai(tiny_df, "ModName", "metric desc", None)
+    messages = openai_client['client'].calls[0]['messages']
+    assert messages[0]['role'] == 'system'
+    assert 'PostgreSQL' in messages[0]['content']
+    assert messages[1]['role'] == 'user'
+    text_parts = [p['text'] for p in messages[1]['content']
+                  if p['type'] == 'text']
+    assert any('ModName' in t and 'metric desc' in t for t in text_parts)
+
+
+def test_analyze_openai_embeds_images_as_data_urls(tiny_df, openai_client,
+                                                   tmp_path):
+    p = tmp_path / "chart.png"
+    p.write_bytes(b"\x89PNG\r\nfake")
+    ai._analyze_openai(tiny_df, "M", "desc", [str(p)])
+    content = openai_client['client'].calls[0]['messages'][1]['content']
+    images = [c for c in content if c['type'] == 'image_url']
+    assert len(images) == 1
+    assert images[0]['image_url']['url'].startswith(
+        "data:image/png;base64,")
+    # Images lead, text trails: same ordering rationale as the other
+    # providers.
+    assert content[-1]['type'] == 'text'
+
+
+def test_analyze_openai_returns_none_on_api_error(tiny_df, monkeypatch,
+                                                  openai_env):
+    def factory(**kwargs):
+        return MockOpenAIClient(raises=Exception("401 authentication failed"))
+
+    monkeypatch.setattr(ai, '_openai_client', factory)
+    assert ai._analyze_openai(tiny_df, "M", "desc", None) is None
+
+
+def test_chat_openai_returns_text(openai_client):
+    assert ai._chat_openai("sys", "user") == "**[HEALTHY]** all good"
+
+
+def test_chat_openai_returns_none_without_key(monkeypatch):
+    monkeypatch.setattr(ai, 'OPENAI_AVAILABLE', True)
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    assert ai._chat_openai("sys", "user") is None
+
+
+def test_analyze_overview_dispatches_to_openai(openai_client):
+    out = ai.analyze_overview(
+        [{'title': 'T', 'verdict': 'HEALTHY', 'summary': 's'}],
+        mode='openai')
+    assert out == "**[HEALTHY]** all good"


### PR DESCRIPTION
OpenAI compatibility and PostgreSQL 19 support
- Add `openai` AI provider: OpenAI and any OpenAI-compatible endpoint
- Add PostgreSQL 19 support
  - Track `wal_fpi_bytes` from `pg_stat_wal`
  - Capture the new PG18/19 I/O worker, WAL level and autovacuum scoring settings in `snapshot_conf`
- Default to `claude-sonnet-5` and `gemini-3.7-flash`
